### PR TITLE
Implement Notes element

### DIFF
--- a/fountain/src/data.rs
+++ b/fountain/src/data.rs
@@ -33,7 +33,7 @@ pub enum Line {
     Transition(String),
     /// [Lyrics](https://fountain.io/syntax#section-lyrics) are lines starting with a tilde (~).
     Lyric(String),
-    /// [Notes](https://fountain.io/syntax) are lines that are wrapped in double brackets ([[]]).
+    /// [Notes](https://fountain.io/syntax/#notes) are lines that are wrapped in double brackets ([[]]).
     Note(String),
 }
 

--- a/fountain/src/data.rs
+++ b/fountain/src/data.rs
@@ -33,6 +33,8 @@ pub enum Line {
     Transition(String),
     /// [Lyrics](https://fountain.io/syntax#section-lyrics) are lines starting with a tilde (~).
     Lyric(String),
+    /// [Notes](https://fountain.io/syntax) are lines that are wrapped in double brackets ([[]]).
+    Note(String),
 }
 
 impl Line {
@@ -56,6 +58,9 @@ impl Line {
     }
     pub fn is_lyric(&self) -> bool {
         matches!(self, Line::Lyric(_))
+    }
+    pub fn is_note(&self) -> bool {
+        matches!(self, Line::Note(_))
     }
 }
 

--- a/fountain/src/html.rs
+++ b/fountain/src/html.rs
@@ -13,6 +13,7 @@ fn line_as_html(line: &Line) -> String {
         Line::Parenthetical(s) => format!("<p class='parenthetical'>({})</p>", s),
         Line::Transition(s) => format!("<p class='transition'>({})</p>", s),
         Line::Lyric(s) => format!("<p class='lyric'>({})</p>", s),
+        Line::Note(s) => format!("<!--{}-->", s),
     }
 }
 

--- a/fountain/src/parse.rs
+++ b/fountain/src/parse.rs
@@ -123,6 +123,23 @@ fn lyric<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
     let parser = preceded(char('~'), some_line);
     map(context("lyric", parser), |s| Line::Lyric(s.to_owned()))(i)
 }
+
+fn note<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
+    i: &'a str,
+) -> IResult<&'a str, Line, E> {
+    let parser = terminated( in_double_brackets, cut(line_ending));
+    map(context("note", parser), |s: &str| {
+        Line::Note(s.to_string())
+    })(i)
+}
+
+/// Matches "[[x]]" and returns "x"
+fn in_double_brackets<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
+    i: &'a str,
+) -> IResult<&'a str, &'a str, E> {
+    delimited(tag("[["), is_not("]]"), tag("]]"))(i)
+}
+
 fn titlepage_val<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
     i: &'a str,
 ) -> IResult<&'a str, &'a str, E> {

--- a/fountain/src/parse.rs
+++ b/fountain/src/parse.rs
@@ -233,6 +233,7 @@ fn block<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
             map(scene, singleton),
             spd_block,
             sd_block,
+            map(note, singleton),
             map(action, singleton),
         )),
     )(i)

--- a/fountain/src/parse.rs
+++ b/fountain/src/parse.rs
@@ -384,6 +384,21 @@ Pages:
     }
 
     #[test]
+    fn test_in_double_brackets() {
+        let input_text = "[[Where should he go next?]]";
+        let output = in_double_brackets::<(&str, ErrorKind)>(input_text);
+        assert_eq!(output, Ok(("", "Where should he go next?")));
+    }
+
+    #[test]
+    fn test_note(){
+        let input_text = "[[Where should he go next?\nBarcelona?]]\n";
+        let output = note::<(&str, ErrorKind)>(input_text);
+        let expected = Ok(("", Line::Note("Where should he go next?\nBarcelona?".to_owned())));
+        assert_eq!(output, expected);
+    }
+
+    #[test]
     fn test_sd_block() {
         let input_text = "LIBRARIAN\nIs anyone there?\n";
         let output = sd_block::<(&str, ErrorKind)>(input_text);

--- a/fountain/src/parse.rs
+++ b/fountain/src/parse.rs
@@ -124,6 +124,8 @@ fn lyric<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
     map(context("lyric", parser), |s| Line::Lyric(s.to_owned()))(i)
 }
 
+/// Parses a Note. Notes are wrapped in double brackets '[[]]'.
+/// https://fountain.io/syntax/#notes
 fn note<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
     i: &'a str,
 ) -> IResult<&'a str, Line, E> {


### PR DESCRIPTION
Fixes #1 (Implement `Notes` element)

- Adds a `Note` variant to the `Line` enum in `parse.rs`
- Adds two parsers: `note` and `in_double_brackets`
  - Mimics the implementation used for parentheticals.
- Adds unit tests for both parsers